### PR TITLE
Base type interfaces and a further placeholder

### DIFF
--- a/src/libslic3r/SupportMaterial.hpp
+++ b/src/libslic3r/SupportMaterial.hpp
@@ -201,12 +201,25 @@ private:
 	    const MyLayersPtr   &base_layers,
 	    MyLayerStorage      &layer_storage) const;
 
+	// Original method
     // Turn some of the base layers into interface layers.
 	MyLayersPtr generate_interface_layers(
 	    const MyLayersPtr   &bottom_contacts,
 	    const MyLayersPtr   &top_contacts,
 	    MyLayersPtr         &intermediate_layers,
 	    MyLayerStorage      &layer_storage) const;
+
+	// New method for base interface support
+	// Turn some of the base layers into interface layers for number_base_interface_layers == 0.
+	// Create base type interface layers under soluble interfaces to extend adhesion. 	
+	// Turn some of the base layers into base interface layers for number_base_interface_layers > 0.
+	MyLayersPtr generate_interface_layers(
+	    const MyLayersPtr   &bottom_contacts,
+	    const MyLayersPtr   &top_contacts,
+	    MyLayersPtr         &intermediate_layers,
+		size_t              number_base_interface_layers,
+	    MyLayerStorage      &layer_storage) const;
+	
 
 	// Trim support layers by an object to leave a defined gap between
 	// the support volume and the object.
@@ -221,7 +234,17 @@ private:
 	void generate_pillars_shape();
 	void clip_with_shape();
 */
+	// Original method
+	// Produce the actual G-code
+	void generate_toolpaths(
+        const PrintObject	&object,
+        const MyLayersPtr 	&raft_layers,
+        const MyLayersPtr   &bottom_contacts,
+        const MyLayersPtr   &top_contacts,
+        const MyLayersPtr   &intermediate_layers,
+		const MyLayersPtr   &interface_layers) const;
 
+	// New method for base interface support
 	// Produce the actual G-code.
 	void generate_toolpaths(
         const PrintObject	&object,
@@ -229,7 +252,8 @@ private:
         const MyLayersPtr   &bottom_contacts,
         const MyLayersPtr   &top_contacts,
         const MyLayersPtr   &intermediate_layers,
-        const MyLayersPtr   &interface_layers) const;
+		const MyLayersPtr   &interface_layers,
+        const MyLayersPtr   &base_interface_layers) const;
 
 	// Following objects are not owned by SupportMaterial class.
 	const PrintObject 		*m_object;


### PR DESCRIPTION
At the moment soluble support material adhesion is weak due to sparse support layers under soluble support layers. I reported as issue #5823 with pictures, as well. 
I added two modified methods to the SupportMaterial Class and left the old methods untouched, just a small modification due to a supposed bug. The new methods add two base type interface layers to the support structure, in case the extruders are different and soluble support is choosen. Since the feature is conditionally activated, it in general doesn't need a GUI input. But a further GUI option "number of base interface layers" may enabled users to adapt this feature to their needs.

Users of multi extruder printers like to define their own purge/retract procedure during toolchange. But PS always adds a travel retract in case an extruder wasn't used before and thus wasn't retracted by a toolchange retract. Without information about the actual extruded volumen of the next extruder a custom toolchange gcode can't decide when the sclicer does it. Therefore I added an additional placeholder parser key "next_extruder_extruded_volume" to the set_extruder method of the GCode Class.