### PR TITLE
Additional custom toolchange placeholder

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -851,7 +851,7 @@ namespace DoExport {
 	            double extruded_volume = extruder.extruded_volume() + (has_wipe_tower ? wipe_tower_data.used_filament[extruder.id()] * 2.4052f : 0.f); // assumes 1.75mm filament diameter
 	            double filament_weight = extruded_volume * extruder.filament_density() * 0.001;
 	            double filament_cost   = filament_weight * extruder.filament_cost()    * 0.001;
-                auto append = [&extruder](std::pair<std::string, unsigned int> &dst, const char *tmpl, double value) {
+	            auto append = [&extruder, &extruders](std::pair<std::string, unsigned int> &dst, const char *tmpl, double value) {
 	                while (dst.second < extruder.id()) {
 	                    // Fill in the non-printing extruders with zeros.
 	                    dst.first += (dst.second > 0) ? ", 0" : "0";
@@ -891,7 +891,6 @@ namespace DoExport {
     }
 }
 
-#if 0
 // Sort the PrintObjects by their increasing Z, likely useful for avoiding colisions on Deltas during sequential prints.
 static inline std::vector<const PrintInstance*> sort_object_instances_by_max_z(const Print &print)
 {
@@ -904,7 +903,6 @@ static inline std::vector<const PrintInstance*> sort_object_instances_by_max_z(c
             instances.emplace_back(&object->instances()[i]);
     return instances;
 }
-#endif
 
 // Produce a vector of PrintObjects in the order of their respective ModelObjects in print.model().
 std::vector<const PrintInstance*> sort_object_instances_by_model_order(const Print& print)
@@ -1792,7 +1790,7 @@ void GCode::process_layer(
     // Just a reminder: A spiral vase mode is allowed for a single object, single material print only.
     m_enable_loop_clipping = true;
     if (m_spiral_vase && layers.size() == 1 && support_layer == nullptr) {
-        bool enable = (layer.id() > 0 || !print.has_brim()) && (layer.id() >= (size_t)print.config().skirt_height.value && ! print.has_infinite_skirt());
+        bool enable = (layer.id() > 0 || print.config().brim_width.value == 0.) && (layer.id() >= (size_t)print.config().skirt_height.value && ! print.has_infinite_skirt());
         if (enable) {
             for (const LayerRegion *layer_region : layer.regions())
                 if (size_t(layer_region->region()->config().bottom_solid_layers.value) > layer.id() ||
@@ -2593,10 +2591,10 @@ std::string GCode::_extrude(const ExtrusionPath &path, std::string description, 
             throw Slic3r::InvalidArgument("Invalid speed");
         }
     }
-    if (m_volumetric_speed != 0. && speed == 0)
-        speed = m_volumetric_speed / path.mm3_per_mm;
     if (this->on_first_layer())
         speed = m_config.get_abs_value("first_layer_speed", speed);
+    if (m_volumetric_speed != 0. && speed == 0)
+        speed = m_volumetric_speed / path.mm3_per_mm;
     if (m_config.max_volumetric_speed.value > 0) {
         // cap speed with max_volumetric_speed anyway (even if user is not using autospeed)
         speed = std::min(
@@ -2837,6 +2835,7 @@ std::string GCode::set_extruder(unsigned int extruder_id, double print_z)
     // Always reset the extrusion path, even if the tool change retract is set to zero.
     m_wipe.reset_path();
 
+      
     if (m_writer.extruder() != nullptr) {
         // Process the custom end_filament_gcode. set_extruder() is only called if there is no wipe tower
         // so it should not be injected twice.
@@ -2858,24 +2857,35 @@ std::string GCode::set_extruder(unsigned int extruder_id, double print_z)
     std::string toolchange_gcode_parsed;
 
     // Process the custom toolchange_gcode. If it is empty, insert just a Tn command.
+    int prev_extruder_id = -1;
+    if (m_writer.extruder() != nullptr) prev_extruder_id = (int)m_writer.extruder()->id();
+
+    // We inform the writer about what is happening, but we may not use the resulting gcode.
+    std::string toolchange_command = m_writer.toolchange(extruder_id);
+
     if (!toolchange_gcode.empty()) {
         DynamicConfig config;
-        config.set_key_value("previous_extruder", new ConfigOptionInt((int)(m_writer.extruder() != nullptr ? m_writer.extruder()->id() : -1 )));
+        config.set_key_value("previous_extruder", new ConfigOptionInt(prev_extruder_id));
         config.set_key_value("next_extruder",     new ConfigOptionInt((int)extruder_id));
         config.set_key_value("layer_num",         new ConfigOptionInt(m_layer_index));
         config.set_key_value("layer_z",           new ConfigOptionFloat(print_z));
         config.set_key_value("max_layer_z",       new ConfigOptionFloat(m_max_layer_z));
+        //provide a key allowing to disable a toolchange rectractions in a custom_gcode, in case extruder is used first time 
+        config.set_key_value("next_extruder_extruded_volume",   new ConfigOptionFloat((m_writer.extruder() != nullptr) ? m_writer.extruder()->extruded_volume() : -1.)); 
         toolchange_gcode_parsed = placeholder_parser_process("toolchange_gcode", toolchange_gcode, extruder_id, &config);
         gcode += toolchange_gcode_parsed;
         check_add_eol(gcode);
     }
 
-    // We inform the writer about what is happening, but we may not use the resulting gcode.
-    std::string toolchange_command = m_writer.toolchange(extruder_id);
+    
     if (! custom_gcode_changes_tool(toolchange_gcode_parsed, m_writer.toolchange_prefix(), extruder_id))
         gcode += toolchange_command;
     else {
         // user provided his own toolchange gcode, no need to do anything
+        // HINT If extruder is used the first time, one can add a toolchange retract here.
+        //if(m_writer.extruder()->extruded_volume() <= 0.) gcode += this->retract(true);
+        // But this can interfer with purge tower extrusions having travel retracts disabled.
+        // Without this usually a travel rectract is written, which in general should be sufficient!?  
     }
 
     // Set the temperature if the wipe tower didn't (not needed for non-single extruder MM)


### PR DESCRIPTION
Users of multi extruder printers like to define their own purge/retract procedure during toolchange. But PS always adds a travel retract in case an extruder wasn't used before and thus wasn't retracted by a toolchange retract. Without information about the actual extruded volumen of the next extruder a custom toolchange gcode can't decide when the sclicer does it. Therefore I added an additional placeholder parser key "next_extruder_extruded_volume" to the set_extruder method of the GCode Class.
This is my second try to provide a pull request on this topic. Reset my fromer repository, because first I merged this and all other changes to my master and couldn't provide separate pull request anymore.